### PR TITLE
Remove rails assets

### DIFF
--- a/Gemfile.common
+++ b/Gemfile.common
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-source 'https://rails-assets.org'
 
 gem 'pg', require: false
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@ Comable provides a simple way to add e-commerce features to your Ruby on Rails a
 
 ## Installation
 
-1. Add comable and a source in the `Gemfile`:
+1. Add comable in the `Gemfile`:
 
   ```ruby
-  source 'https://rails-assets.org'
-
   gem 'comable'
   ```
 

--- a/backend/app/assets/javascripts/comable/admin/application.coffee
+++ b/backend/app/assets/javascripts/comable/admin/application.coffee
@@ -1,11 +1,11 @@
 #= require jquery
-#= require jquery-ujs
+#= require jquery_ujs
 #= require jquery-ui
 #= require jstree
 #= require bootstrap-sprockets
 #= require raphael
 #= require morris
-#= require pace
+#= require pace/pace
 #= require_tree .
 
 $( ->

--- a/backend/app/assets/stylesheets/comable/admin/application.scss
+++ b/backend/app/assets/stylesheets/comable/admin/application.scss
@@ -599,4 +599,5 @@ ul.vakata-context.jstree-contextmenu {
 // ---
 .pace .pace-progress {
   background-color: $comable-theme-bg !important;
+  @include transition-property(none);
 }

--- a/backend/app/assets/stylesheets/comable/admin/application.scss
+++ b/backend/app/assets/stylesheets/comable/admin/application.scss
@@ -1,7 +1,7 @@
 //= require jquery-ui
-//= require jstree
+//= require jstree/themes/default/style
 //= require morris
-//= require pace/themes/purple/pace-theme-minimal
+//= require pace/pace-theme-minimal
 //= require_self
 //= require_tree .
 
@@ -10,6 +10,11 @@
 @import 'bootstrap-sprockets';
 @import 'bootstrap';
 @import 'font-awesome';
+
+// ---
+// variables
+// ---
+$comable-theme-bg: #7761a7;
 
 // ---
 // mixins
@@ -90,7 +95,7 @@ margin-right: auto;
   line-height: 64px;
   background-color: #fc796b;
   background-color: #e55466;
-  background-color: #7761a7;
+  background-color: $comable-theme-bg;
 
   a {
     font-size: x-large;
@@ -587,4 +592,11 @@ ul.vakata-context.jstree-contextmenu {
   color: #ccc !important;
   background: rgba(0, 0, 0, 0.75) !important;
   border: none !important;
+}
+
+// ---
+// pace
+// ---
+.pace .pace-progress {
+  background-color: $comable-theme-bg !important;
 }

--- a/backend/comable_backend.gemspec
+++ b/backend/comable_backend.gemspec
@@ -26,10 +26,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari'
   s.add_dependency 'ransack'
 
-  s.add_dependency 'rails-assets-jquery', '~> 2.1.3'
-  s.add_dependency 'rails-assets-jquery-ujs'
-  s.add_dependency 'rails-assets-jstree', '~> 3.0.9'
-  s.add_dependency 'rails-assets-raphael', '~> 2.1.3'
-  s.add_dependency 'rails-assets-morris', '~> 0.5.2'
-  s.add_dependency 'rails-assets-pace', '~> 1.0.2'
+  s.add_dependency 'jquery-rails', '~> 3.1.2', '<= 4.0.3'
+  s.add_dependency 'jquery-ui-rails', '~> 5.0.3'
+  s.add_dependency 'jstree-rails', '~> 0.0.4'
+  s.add_dependency 'raphael-rails', '~> 2.1.2'
+  s.add_dependency 'morrisjs-rails', '~> 0.5.1'
+  s.add_dependency 'pace-rails', '~> 0.1.1'
 end

--- a/backend/lib/comable/backend/engine.rb
+++ b/backend/lib/comable/backend/engine.rb
@@ -9,12 +9,12 @@ require 'font-awesome-rails'
 require 'kaminari'
 require 'ransack'
 
-require 'rails-assets-jquery'
-require 'rails-assets-jquery-ujs'
-require 'rails-assets-jstree'
-require 'rails-assets-raphael'
-require 'rails-assets-morris'
-require 'rails-assets-pace'
+require 'jquery-rails'
+require 'jquery-ui-rails'
+require 'jstree-rails'
+require 'raphael-rails'
+require 'morrisjs-rails'
+require 'pace/rails'
 
 module Comable
   module Backend

--- a/core/lib/comable_core.rb
+++ b/core/lib/comable_core.rb
@@ -1,4 +1,5 @@
 require 'devise'
+require 'jquery-rails'
 require 'enumerize'
 require 'state_machine'
 require 'ancestry'

--- a/frontend/app/assets/javascripts/comable/frontend/application.coffee
+++ b/frontend/app/assets/javascripts/comable/frontend/application.coffee
@@ -1,5 +1,5 @@
 #= require jquery
-#= require jquery-ujs
+#= require jquery_ujs
 #= require jquery-ui
 #= require bootstrap-sprockets
 #= require_tree

--- a/frontend/comable_frontend.gemspec
+++ b/frontend/comable_frontend.gemspec
@@ -21,11 +21,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'coffee-rails'
   s.add_dependency 'compass-rails'
   s.add_dependency 'uglifier'
+  s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails'
+  s.add_dependency 'normalize-rails'
   s.add_dependency 'bootstrap-sass'
   s.add_dependency 'font-awesome-rails'
   s.add_dependency 'kaminari'
-
-  s.add_dependency 'rails-assets-jquery', '~> 2.1.3'
-  s.add_dependency 'rails-assets-jquery-ujs'
 end

--- a/frontend/comable_frontend.gemspec
+++ b/frontend/comable_frontend.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'coffee-rails'
   s.add_dependency 'compass-rails'
   s.add_dependency 'uglifier'
-  s.add_dependency 'jquery-rails'
-  s.add_dependency 'jquery-ui-rails'
-  s.add_dependency 'normalize-rails'
   s.add_dependency 'bootstrap-sass'
   s.add_dependency 'font-awesome-rails'
   s.add_dependency 'kaminari'
+
+  s.add_dependency 'jquery-rails', '~> 3.1.2', '<= 4.0.3'
+  s.add_dependency 'jquery-ui-rails', '~> 5.0.3'
 end

--- a/frontend/lib/comable/frontend/engine.rb
+++ b/frontend/lib/comable/frontend/engine.rb
@@ -1,12 +1,13 @@
 require 'comable_core'
 
 require 'slim'
-require 'jquery-rails'
-require 'jquery-ui-rails'
 require 'bootstrap-sass'
 require 'sass-rails'
 require 'compass-rails'
 require 'kaminari'
+
+require 'jquery-rails'
+require 'jquery-ui-rails'
 
 module Comable
   module Frontend

--- a/frontend/lib/comable/frontend/engine.rb
+++ b/frontend/lib/comable/frontend/engine.rb
@@ -1,14 +1,12 @@
 require 'comable_core'
 
 require 'slim'
+require 'jquery-rails'
 require 'jquery-ui-rails'
 require 'bootstrap-sass'
 require 'sass-rails'
 require 'compass-rails'
 require 'kaminari'
-
-require 'rails-assets-jquery'
-require 'rails-assets-jquery-ujs'
 
 module Comable
   module Frontend


### PR DESCRIPTION
Because the gem that are registered in ruby-gems.org cannot use gems of rails-assets.org.